### PR TITLE
Loosen restrictive appearance prop type on Button component

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -431,7 +431,7 @@ Button.propTypes = {
   */
   isLink: PropTypes.bool,
   children: PropTypes.node.isRequired,
-  appearance: PropTypes.oneOf(['primary', 'secondary', 'tertiary', 'outline']),
+  appearance: PropTypes.string,
   disabled: PropTypes.bool,
   /**
    Prevents users from clicking on a button multiple times (for things like payment forms)


### PR DESCRIPTION
The stories indicate that you can pass multiple appearances to `Button`s (`"outline primary"`). Therefore, the appearance prop type validation has to either just look for a string or we create some custom PropType checker for the button. Prob easier right now to just check for a string.